### PR TITLE
fix(maps): Ensure previous map pins are cleared when rendering

### DIFF
--- a/src/maps/src/main.ts
+++ b/src/maps/src/main.ts
@@ -17,6 +17,7 @@ type Place = {
 
 let map;
 let infoWindow;
+let currentMarkers: google.maps.marker.AdvancedMarkerElement[] = [];
 
 const loader = new Loader({
   apiKey: import.meta.env.VITE_PUBLIC_MAPS_API_KEY,
@@ -125,9 +126,19 @@ async function renderPinsForPlaces(places: Place[]) {
       infoWindow.open(marker.map, marker);
     });
 
+    currentMarkers.push(marker);
+
     bounds.extend(place.location);
   });
   map.fitBounds(bounds);
+}
+
+function clearAllPins() {
+  currentMarkers.forEach((marker) => {
+    marker.map = null;
+  });
+
+  currentMarkers = [];
 }
 
 function errorHasMessage(error: unknown): error is { message: string } {
@@ -223,6 +234,8 @@ context.defineAction("search", {
 });
 
 context.ondata = () => {
+  clearAllPins();
+
   if (context.data.error) {
     renderAlert(context.data.error);
   }


### PR DESCRIPTION
When we have a query result, we render pins to the map, when we then do a subsequent query, we do not clear the previous map data even though we do clear the context data.

Keep a reference array of our map markers when we create them, then clear out the reference array every time we run `ondata`.

![maps-re-render](https://github.com/user-attachments/assets/a3424684-48b6-4258-9260-c4c174fdc78b)
