### PR TITLE
fix(maps): use `onload` from the applet context for initialising the map

### DIFF
--- a/src/maps/src/main.ts
+++ b/src/maps/src/main.ts
@@ -231,4 +231,6 @@ context.ondata = () => {
   }
 };
 
-initialiseMap();
+context.onload = async () => {
+  await initialiseMap();
+};


### PR DESCRIPTION
`onload` isn't currently documented, but I recall last week (or the week prior??) you mentioned I should wrap the initialise method with it.